### PR TITLE
add alt-text to DOI badge image

### DIFF
--- a/episodes/08-open-collaboration.md
+++ b/episodes/08-open-collaboration.md
@@ -142,7 +142,7 @@ If you click on the DOI image in the Details section of the Zenodo page then you
 obtaining a link to the DOI badge in various formats including Markdown.
 Here is the badge for this repository and the corresponding Markdown: 
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11869450.svg)](https://doi.org/10.5281/zenodo.11869450)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11869450.svg)](https://doi.org/10.5281/zenodo.11869450){alt='styled button linking to the Zenodo entry for this lesson'}
 
 ```text
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11869450.svg)](https://doi.org/10.5281/zenodo.11869450)


### PR DESCRIPTION
Another very minor polish: I think it is good to include alt text on the badge displayed in the lesson site, even though we do not need to include it in the code block underneath.