### PR TITLE
removing extra imports that were removed in the last episode

### DIFF
--- a/episodes/05-code-structure.md
+++ b/episodes/05-code-structure.md
@@ -286,9 +286,6 @@ code as a list - remember to import this library first.
 Our modified code will now look as follows.
 
 ```python
-import json
-import csv
-import datetime as dt
 import matplotlib.pyplot as plt
 import pandas as pd
 import sys

--- a/episodes/05-code-structure.md
+++ b/episodes/05-code-structure.md
@@ -454,6 +454,7 @@ Common categories include:
    - Use tags/releases to mark specific versions of results (a version submitted to a journal, dissertation version, poster version, etc.)
    so as to avoid using version numbers in file names and proliferation of different files.
 
+Below is an example diagram of a project structure that follows these practices:
 
 ```output
 project_name/


### PR DESCRIPTION
I did a full review of episode 5 but only found one small change - we removed the import statements for libraries that aren't used in the last episode but they reappeared in one of the code blocks.

I also had a bigger issue that I filed as #252 that requires some discussion.