### PR TITLE
Remove broken learner profile link

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,8 +10,6 @@ The course can be delivered over 2 full or 4 half days.
 - Post-graduate students, early career researchers or junior Research Software Engineers (RSEs) who are starting their research or software projects, have foundational knowledge of Python, version control and using software tools from command line shell, and want to develop software to support their research using established best practices
 - Researchers or scientists who had foundational software training before but wish to refresh, reinforce or improve their skills and practices in the wider context of FAIR scientific practice and sharing and writing software for open and reproducible research 
 
-Check out a few example [learner profiles](./profiles/learner-profiles.md), to see if this course is a right fit for you.
-
 ::::::::::::::::::::::::::::::::::::::::::  prereq
 
 ## Prerequisites


### PR DESCRIPTION
Remove link to learner profile page and related sentence. Alternatively, if there are learner profiles, they can be added to the linked page, in which case this PR can be closed as unnecessary.