### PR TITLE
Correct link for learner profiles

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ The course can be delivered over 2 full or 4 half days.
 - Post-graduate students, early career researchers or junior Research Software Engineers (RSEs) who are starting their research or software projects, have foundational knowledge of Python, version control and using software tools from command line shell, and want to develop software to support their research using established best practices
 - Researchers or scientists who had foundational software training before but wish to refresh, reinforce or improve their skills and practices in the wider context of FAIR scientific practice and sharing and writing software for open and reproducible research 
 
-Check out a few example [learner profiles](./profiles/learner-profiles.md), to see if this course is a right fit for you.
+Check out a few example [learner profiles](./profiles.html), to see if this course is a right fit for you.
 
 ::::::::::::::::::::::::::::::::::::::::::  prereq
 


### PR DESCRIPTION
Replace broken link to learner profiles page in setup with correct link. Replaces #298.