### PR TITLE
Add `reset_index()` to `summary_duration_by_astronaut` function

### DIFF
--- a/episodes/08-open-collaboration.md
+++ b/episodes/08-open-collaboration.md
@@ -342,7 +342,8 @@ def summary_duration_by_astronaut(df):
     subset = df.loc[:,['crew', 'duration']] # subset to work with only relevant columns
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
     subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
-    subset = subset.groupby('crew').sum() 
+    subset = subset.groupby('crew').sum()
+    subset = subset.reset_index()
     return subset
 ```
 
@@ -545,6 +546,7 @@ def summary_duration_by_astronaut(df):
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
     subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
     subset = subset.groupby('crew').sum() 
+    subset = subset.reset_index()
     return subset
 
 
@@ -750,7 +752,8 @@ def summary_duration_by_astronaut(df):
     subset = subset.explode('crew') # separating lists of crew into individual rows
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
     subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
-    subset = subset.groupby('crew').sum() 
+    subset = subset.groupby('crew').sum()
+    subset = subset.reset_index()
     return subset
 ```
 

--- a/episodes/08-open-collaboration.md
+++ b/episodes/08-open-collaboration.md
@@ -343,7 +343,7 @@ def summary_duration_by_astronaut(df):
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
     subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
     subset = subset.groupby('crew').sum()
-    subset = subset.reset_index()
+    subset = subset.reset_index() # make group index a column in the dataframe
     return subset
 ```
 
@@ -546,7 +546,7 @@ def summary_duration_by_astronaut(df):
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
     subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
     subset = subset.groupby('crew').sum() 
-    subset = subset.reset_index()
+    subset = subset.reset_index() # make group index a column in the dataframe
     return subset
 
 
@@ -753,7 +753,7 @@ def summary_duration_by_astronaut(df):
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
     subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
     subset = subset.groupby('crew').sum()
-    subset = subset.reset_index()
+    subset = subset.reset_index() # make group index a column in the dataframe
     return subset
 ```
 

--- a/episodes/08-open-collaboration.md
+++ b/episodes/08-open-collaboration.md
@@ -341,7 +341,7 @@ def summary_duration_by_astronaut(df):
     print(f'Calculating summary of total EVA time by astronaut')
     subset = df.loc[:,['crew', 'duration']] # subset to work with only relevant columns
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
-    subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
+    subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calculations
     subset = subset.groupby('crew').sum()
     subset = subset.reset_index() # make group index a column in the dataframe
     return subset
@@ -544,7 +544,7 @@ def summary_duration_by_astronaut(df):
     print(f'Calculating summary of total EVA time by astronaut')
     subset = df.loc[:,['crew', 'duration']] # subset to work with only relevant columns
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
-    subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
+    subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calculations
     subset = subset.groupby('crew').sum() 
     subset = subset.reset_index() # make group index a column in the dataframe
     return subset
@@ -751,7 +751,7 @@ def summary_duration_by_astronaut(df):
     subset.crew = subset.crew.str.split(';').apply(lambda x: [i for i in x if i.strip()]) # splitting the crew into individuals and removing blank string splits from ending ;
     subset = subset.explode('crew') # separating lists of crew into individual rows
     subset = add_duration_hours(subset) # need duration_hours for easier calcs
-    subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calulations
+    subset = subset.drop('duration', axis=1) # dropping the extra 'duration' column as it contains string values not suitable for calculations
     subset = subset.groupby('crew').sum()
     subset = subset.reset_index() # make group index a column in the dataframe
     return subset


### PR DESCRIPTION
Fix #373 by adding `reset_index()` to make saved output contain the `crew` column. This also makes the challenge involving identifying a bug in the output clearer.

Also fixes a typo in a comment within the same function.