### PR TITLE
Remove callout recommending use of autoDocstring

### DIFF
--- a/episodes/04-code-readability.md
+++ b/episodes/04-code-readability.md
@@ -887,15 +887,6 @@ Remember, questions we want to answer when writing the docstring include:
 - What output will the function produce?
 - What exceptions/errors, if any, it can produce?
 
-::: callout
-
-### autoDocstring: VS Code Python Docstring Generator
-
-While we can write docstrings manually, [VS Code extension autoDocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) and other similar tools can help create the scaffolding for docstrings and speed up the process immensely.
-We highly recommend installing it for Python development.
-
-:::
-
 Our `read_json_to_dataframe` function fully described by a docstring may look like:
 
 ```python

--- a/learners/installation-instructions.md
+++ b/learners/installation-instructions.md
@@ -358,12 +358,6 @@ You can also change the default command line terminal from the same drop down me
 ![*Terminal window in VS Code*](fig/vscode-terminal.png){alt="Screenshot of the terminal pane in VS Code highlighting the current terminal type and dropdown menu to open a new terminal with 'Select Default Profile' option highlighted in the menu"}
 :::
 
-#### autoDocstring - VS Code Python docstring generator extension (optional)
-
-You can optionally install [autoDocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) - VS Code extension to quickly generate docstrings for Python functions.
-It is a very useful extension that can impove and speed up your Python development.
-
-
 #### VS Code extensions for Git (optional)
 
 You can optionally install the following VS Code extensions (from `View > Extensions` top-level menu) to make your Git experience in VS Code better:


### PR DESCRIPTION
Fix #377.

The autoDocstring VS Code extension has not been updated since 2022 and appears to be abandoned. There have been cases of VS Code extensions being exploited in the past, so it may be safer to limit extensions endorsed by this workshop to official/verified ones.

Learners can instead write one from scratch as an exercise and this may encourage them to better consider different sections needed.